### PR TITLE
fix: Changes sonatype repo url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,11 @@ SOFTWARE.
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
   <dependencyManagement>


### PR DESCRIPTION
Closes #28

- Changes url from `oss.sonatype.org` to `s01.oss.sonatype.org`